### PR TITLE
Add unescaped option to toString

### DIFF
--- a/lib/rdn.js
+++ b/lib/rdn.js
@@ -145,9 +145,20 @@ class RDN {
    * rnd.toString()
    * // => 'cn=\23foo+1.3.6.1.4.1.1466.0=#04024869'
    *
+   * @example Unescaped Value
+   * const rdn = new RDN({
+   *   cn: '#foo'
+   * })
+   * rdn.toString({ unescaped: true })
+   * // => 'cn=#foo'
+   *
+   * @param {object} [options]
+   * @param {boolean} [options.unescaped=false] Return the unescaped version
+   * of the RDN string.
+   *
    * @returns {string}
    */
-  toString () {
+  toString ({ unescaped = false } = {}) {
     let result = ''
     const isHexEncodedValue = val => /^#([0-9a-fA-F]{2})+$/.test(val) === true
 
@@ -163,7 +174,7 @@ class RDN {
         }
         result += encoded
       } else {
-        result += escapeValue(entry.value)
+        result += unescaped === false ? escapeValue(entry.value) : entry.value
       }
 
       result += '+'

--- a/lib/rdn.test.js
+++ b/lib/rdn.test.js
@@ -132,6 +132,13 @@ tap.test('toString', t => {
     t.equal(rdn.toString(), 'cn=#0403666f6f')
   })
 
+  t.test('honors unescaped options', async t => {
+    const rdn = new RDN({
+      ou: '研发二组'
+    })
+    t.equal(rdn.toString({ unescaped: true }), 'ou=研发二组')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Allows for displaying RDNs in a human friendly way. Resolves https://github.com/ldapjs/node-ldapjs/issues/876.