### PR TITLE
fix: The DN was created in Chinese, but the AD failed to be created

### DIFF
--- a/lib/utils/escape-value.js
+++ b/lib/utils/escape-value.js
@@ -58,11 +58,7 @@ module.exports = function escapeValue (value) {
 
     if (charHex >= 0xe0 && charHex <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
-      escaped.push(toEscapedHexString(charHex))
-      escaped.push(toEscapedHexString(toEscape[i + 1]))
-      escaped.push(toEscapedHexString(toEscape[i + 2]))
-      i += 3
-      continue
+      return value
     }
 
     if (charHex >= 0xf0 && charHex <= 0xf7) {


### PR DESCRIPTION
When i try to create AD DN with Chinese, it will show error "Invalid Dn Syntax".
It can't be transcoded. Otherwise it will cause error