### PR TITLE
a 3-byte UTF-8 character don't convert to hex string，ldap server can support \u or \U, but it is'n support hex string

### DIFF
--- a/lib/utils/escape-value.js
+++ b/lib/utils/escape-value.js
@@ -58,9 +58,7 @@ module.exports = function escapeValue (value) {
 
     if (charHex >= 0xe0 && charHex <= 0xef) {
       // Represents the first byte in a 3-byte UTF-8 character.
-      escaped.push(toEscapedHexString(charHex))
-      escaped.push(toEscapedHexString(toEscape[i + 1]))
-      escaped.push(toEscapedHexString(toEscape[i + 2]))
+      escaped.push(Buffer.from([charHex, toEscape[i + 1], toEscape[i + 2]], 'utf8').toString())
       i += 3
       continue
     }

--- a/lib/utils/escape-value.test.js
+++ b/lib/utils/escape-value.test.js
@@ -47,7 +47,11 @@ tap.test('2-byte utf-8', t => {
 
 tap.test('3-byte utf-8', t => {
   t.test('₠', async t => {
-    t.equal(escapeValue('₠'), '\\e2\\82\\a0')
+    t.equal(escapeValue('₠'), '₠')
+  })
+
+  t.test('中文', async t => {
+    t.equal(escapeValue('中文'), '中文')
   })
 
   t.end()


### PR DESCRIPTION
Related PR: https://github.com/ldapjs/dn/pull/2

a 3-byte UTF-8 character don't convert to hex string，ldap server can support \u or \U, but it is'n support hex string（3位的utf8字符不应该转换成16进制串，ldap服务端只支持\uxxx、\Uxxx这种编码，但不是16进制串）

Hope to review as soon as possible（希望尽快review）